### PR TITLE
Fix errors that occurred when parsing document

### DIFF
--- a/sphinx_asdf/connections.py
+++ b/sphinx_asdf/connections.py
@@ -99,6 +99,12 @@ def handle_page_context(app, pagename, templatename, ctx, doctree):
         return os.path.join(TEMPLATE_PATH, 'schema.html')
 
 
+def normalize_name(name):
+    for char in ['.', '_', '/']:
+        name = name.replace(char, '-')
+    return name
+
+
 def add_labels_to_nodes(app, document):
     labels = app.env.domaindata['std']['labels']
     anonlabels = app.env.domaindata['std']['anonlabels']
@@ -111,7 +117,11 @@ def add_labels_to_nodes(app, document):
         labelid = node['ids'][0]
         docname = app.env.docname
         basename = os.path.relpath(docname, basepath)
-        name = nodes.fully_normalize_name(basename + ':' + labelid)
+
+        if labelid == normalize_name(basename):
+            name = basename
+        else:
+            name = nodes.fully_normalize_name(basename + ':' + labelid)
 
         # labelname -> docname, labelid
         anonlabels[name] = docname, labelid

--- a/sphinx_asdf/connections.py
+++ b/sphinx_asdf/connections.py
@@ -4,7 +4,7 @@ import posixpath
 
 from docutils import nodes
 from sphinx.io import read_doc
-from sphinx.util import rst
+from sphinx.util import rst, logger, logging
 from sphinx.util.fileutil import copy_asset
 from sphinx.util.docutils import sphinx_domains
 
@@ -17,10 +17,15 @@ TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), 'templates')
 
 def find_autoasdf_directives(env, filename):
 
+    orig_level = logger.getEffectiveLevel()
+    logger.setLevel(logging.LEVEL_NAMES['ERROR'])
+
     docname = env.path2doc(filename)
     env.prepare_settings(docname)
     with sphinx_domains(env), rst.default_role(docname, env.config.default_role):
         doctree = read_doc(env.app, env, env.doc2path(docname))
+
+    logger.setLevel(orig_level)
 
     return [x.children[0].astext() for x in doctree.traverse(schema_def)]
 


### PR DESCRIPTION
This fixed a number of errors that occurred while parsing the document while looking for `autoasdf` directives. It also silences irrelevant warnings during this phase. Finally, it makes use of the `autosectionlabel` plugin unnecessary since this plugin appears to cause conflicts with Astropy's `automodapi` plugin.