### PR TITLE
Only add asdf-specific JS and CSS to schema pages

### DIFF
--- a/sphinx_asdf/__init__.py
+++ b/sphinx_asdf/__init__.py
@@ -21,9 +21,6 @@ def setup(app):
 
     add_asdf_nodes(app)
 
-    app.add_css_file('sphinx_asdf.css')
-    app.add_js_file('sphinx_asdf.js')
-
     app.connect('builder-inited', autogenerate_schema_docs)
     app.connect('config-inited', update_app_config)
     app.connect('html-page-context', handle_page_context)

--- a/sphinx_asdf/templates/schema.html
+++ b/sphinx_asdf/templates/schema.html
@@ -1,4 +1,9 @@
 {% extends "!page.html" %}
+{%- block scripts %}
+    {{ super() }}
+    <link rel="stylesheet" type="text/css" href="{{ pathto('_static/sphinx_asdf.css', 1) }}">
+    <script type="text/javascript" src="{{ pathto('_static/sphinx_asdf.js', 1) }}"></script>
+{%- endblock %}
 {% block extrahead %}
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>


### PR DESCRIPTION
This PR ensures that the sphinx-asdf-specific JS and CSS only gets added to schema pages. Currently it gets added to all pages which creates issues in e.g. the core astropy docs: https://github.com/astropy/astropy/issues/8631